### PR TITLE
fix: "An operation is not implemented: Not yet implemented"

### DIFF
--- a/android/src/main/kotlin/com/hustlance/flutter_ui_mode_manager/FlutterUiModeManagerPlugin.kt
+++ b/android/src/main/kotlin/com/hustlance/flutter_ui_mode_manager/FlutterUiModeManagerPlugin.kt
@@ -80,7 +80,7 @@ public class FlutterUiModeManagerPlugin: FlutterPlugin, MethodCallHandler, Activ
   }
 
   override fun onDetachedFromActivityForConfigChanges() {
-    TODO("Not yet implemented")
+    // No cleanup needed for config changes
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
@@ -88,6 +88,6 @@ public class FlutterUiModeManagerPlugin: FlutterPlugin, MethodCallHandler, Activ
   }
 
   override fun onDetachedFromActivity() {
-    TODO("Not yet implemented")
+    // No cleanup needed when detaching from activity
   }
 }


### PR DESCRIPTION
When closing an app with this library installed, one gets a 

```bash
q8.l: An operation is not implemented: Not yet implemented
    at l7.a.onDetachedFromActivity(FlutterUiModeManagerPlugin.kt:11)
    at io.flutter.embedding.engine.c.h(FlutterEngineConnectionRegistry.java:34)
    at io.flutter.embedding.android.e.t(FlutterActivityAndFragmentDelegate.java:59)
    at io.flutter.embedding.android.d.onDestroy(FlutterActivity.java:19)
    at android.app.Activity.performDestroy(Activity.java:8288)
    at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1344)
    at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5142)
    at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5186)
    at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:44)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2081)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:223)
    at android.app.ActivityThread.main(ActivityThread.java:7719)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```

This is because of this [TODO](https://github.com/Bizubani/flutter_ui_mode_manager/blob/master/android/src/main/kotlin/com/hustlance/flutter_ui_mode_manager/FlutterUiModeManagerPlugin.kt#L91)

Removing this avoids this error.